### PR TITLE
Refactor(graphql): added mutation for PostCreate and PostDelete

### DIFF
--- a/server/src/modules/posts/PostLoader.js
+++ b/server/src/modules/posts/PostLoader.js
@@ -1,9 +1,6 @@
 import PostModel from './PostModel'
 
-export async function loadAll() {
-    const posts = await PostModel
-    if(!posts){
-      return null
-    }
-    return posts
+export function loadAll() {
+  const posts = PostModel.find().lean()
+  return posts 
 }

--- a/server/src/modules/posts/mutations/PostCreate.js
+++ b/server/src/modules/posts/mutations/PostCreate.js
@@ -1,0 +1,70 @@
+import {GraphQLNonNull, GraphQLString} from 'graphql';
+import { mutationWithClientMutationId, toGlobalId }  from 'graphql-relay';
+
+import * as PostLoader from '../PostLoader';
+import PostModel from '../PostModel'
+import { PostConnection } from '../PostType' 
+
+const mutation = mutationWithClientMutationId({
+    name: 'PostCreate',
+    inputFields: {
+        title: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        content: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        tag: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        link: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+    },
+    mutateAndGetPayload: async ({ title, content, tag, link }) => {
+        try {
+            const post = await PostModel.create({
+                title,
+                content,
+                tag,
+                link
+            })
+            return {
+                post,
+                success: 'Post created successfully',  
+                error: null,
+            }
+        }catch (e) {
+            return {
+                post: null,
+                success: '',
+                error: e,
+            }
+        }
+    },
+    outputFields: {
+        postEdge: {
+            type: PostConnection.edgeType,
+            resolve: async ({ post }) => {
+                // Returns null if no node was loaded
+                if (!post) {
+                    return null;
+                }
+                return {
+                    cursor: toGlobalId('Post', post._id),
+                    node: post,
+                }
+            },
+        },
+        error: {
+            type: GraphQLString,
+            resolve: ({ error }) => error
+        },
+        success: {
+            type: GraphQLString,
+            resolve: ({ success }) => success
+        },
+    },
+});
+
+export default mutation

--- a/server/src/modules/posts/mutations/PostDelete.js
+++ b/server/src/modules/posts/mutations/PostDelete.js
@@ -1,0 +1,40 @@
+import {GraphQLNonNull, GraphQLString} from 'graphql';
+import { mutationWithClientMutationId, toGlobalId }  from 'graphql-relay';
+
+import PostModel from '../PostModel'
+import PostType from '../PostType' 
+import * as PostLoader from '../PostLoader';
+
+const mutation = mutationWithClientMutationId ({
+    name: 'PostDelete',
+    inputFields: {
+        _id: {
+            type: GraphQLNonNull(GraphQLString),
+        }
+    },
+    mutateAndGetPayload: async ({ _id, title, content, tag, link }) => {
+        const postDelete = await PostModel.findOneAndDelete({ _id: _id })
+        await postDelete.remove()
+
+        return {
+            postDelete,
+            success: 'Post deleted with successfully',
+            error: null,
+        }
+    },
+    outputFields:{
+        postDelete:{
+            type: PostType,
+            resolve: ({ postDelete }) => postDelete
+        },
+        error: {
+            type: GraphQLString,
+            resolve: ({ error }) => error
+        },
+        success: {
+            type: GraphQLString,
+            resolve: ({ success }) => success
+        },
+    }
+})
+export default mutation

--- a/server/src/modules/posts/mutations/createPost.js
+++ b/server/src/modules/posts/mutations/createPost.js
@@ -1,0 +1,87 @@
+import {GraphQLNonNull, GraphQLString} from 'graphql';
+import { mutationWithClientMutationId, toGlobalId, connectionFromArray }  from 'graphql-relay';
+
+import * as PostLoader from '../PostLoader';
+import PostModel from '../PostModel'
+import { PostConnection } from '../PostType' 
+
+const load = async (context, id) => {
+    if (!id) {
+      return null;
+    }
+
+    try {
+      const data = await context.dataloaders.load(id.toString());
+
+      if (!data) {
+        return null;
+      }
+
+      const filteredData = await viewerCanSee(context, data);
+
+      return filteredData ? (new Wrapper(filteredData)) : null;
+    } catch (err) {
+      return null;
+    }
+  };
+
+const mutation = mutationWithClientMutationId({
+    name: 'createPost',
+    inputFields: {
+        title: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        content: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        tag: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        link: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+    },
+    mutateAndGetPayload: async ({ title, content, tag, link }) => {
+
+        const post = await new PostModel({
+            title,
+            content,
+            tag,
+            link
+        }).save()
+
+        return {
+            id: post._id
+        };
+    },
+    outputFields: {
+        postEdge: {
+            type: PostConnection.edgeType,
+            resolve: async ({ id }, _, context) => {
+                // Load new edge from loader
+                const post = await PostLoader.load(context, id);
+
+                console.log(context, id);
+                // Returns null if no node was loaded
+                if (!post) {
+                return null;
+                }
+                return {
+                cursor: toGlobalId('Post', post._id),
+                node: post,
+                };
+            },
+        },
+        error: {
+            type: GraphQLString,
+            resolve: ({ error }) => error
+        },
+        success: {
+            type: GraphQLString,
+            resolve: ({ success }) => success
+        }
+    },
+});
+console.log(mutation)
+  
+export default mutation

--- a/server/src/modules/posts/mutations/index.js
+++ b/server/src/modules/posts/mutations/index.js
@@ -1,0 +1,5 @@
+import createPost from "./createPost"
+
+export default {
+    createPost
+}

--- a/server/src/modules/posts/mutations/index.js
+++ b/server/src/modules/posts/mutations/index.js
@@ -1,5 +1,7 @@
-import createPost from "./createPost"
+import PostCreate from "./PostCreate"
+import PostDelete from "./PostDelete"
 
 export default {
-    createPost
+    PostCreate,
+    PostDelete,
 }

--- a/server/src/schema/MutationType.js
+++ b/server/src/schema/MutationType.js
@@ -1,0 +1,11 @@
+import { GraphQLObjectType } from 'graphql'
+
+import PostMutation from '../modules/posts/mutations'
+
+const MutationType = new GraphQLObjectType({ 
+    name: 'Mutation',
+    fields: () => ({
+        ...PostMutation
+    })
+})
+export default MutationType


### PR DESCRIPTION
I think my PostCreate still gives me an error at the cursor: toGlobalId, I tested it in the query and it gave me an error, I believe this is messing up my PostDelete 